### PR TITLE
Mergify for scala-steward patch updates

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,9 @@
+pull_request_rules:
+  - name: automatically merge scala-steward's PRs
+    conditions:
+      - author=scala-steward
+      - body~=labels:.*semver-patch
+      - status-success=Travis CI - Pull Request
+    actions:
+      merge:
+        method: squash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# cats-process - Functional command and process [![Build Status](https://travis-ci.com/cats4scala/cats-process.svg?branch=master)](https://travis-ci.com/cats4scala/cats-process) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/cats4scala/cats-process_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/c4s/cats-process_2.12) ![Code of Consuct](https://img.shields.io/badge/Code%20of%20Conduct-Scala-blue.svg)
+[![Build Status][travisci-status]][travisci] [![Maven Central](https://maven-badges.herokuapp.com/maven-central/cats4scala/cats-process_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/c4s/cats-process_2.12) ![Code of Consuct](https://img.shields.io/badge/Code%20of%20Conduct-Scala-blue.svg) [![Mergify Status][mergify-status]][mergify]
+
+# cats-process - Functional command and process
 
 [Head on over to the microsite](https://cats4scala.github.io/cats-process)
 
@@ -12,3 +14,7 @@ libraryDependencies ++= Seq(
   "c4s" %% "cats-process" % "<version>"
 )
 ```
+[travisci]: https://travis-ci.com/cats4scala/cats-process
+[travisci-status]: https://travis-ci.com/cats4scala/cats-process.svg?branch=master
+[mergify]: https://mergify.io
+[mergify-status]: https://img.shields.io/endpoint.svg?url=https://gh.mergify.io/badges/cats4scala/cats-process&style=flat


### PR DESCRIPTION
This change has been made by @JesusMtnez from https://mergify.io simulator.

Close #15 
Blocked until #16 

---

<details>
<summary>Mergify commands and options</summary>
<br />
More conditions and actions can be found in the [documention](https://doc.mergify.io/).
<br />
<br />
You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR
- `@Mergifyio backports <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.io/) you can:

- look at your merge queues
- generate the Mergify configuration with the simulator.

Finally, you can contact us on https://mergify.io/
</details>
