### PR TITLE
Support crossbuild for Scala 2.13.1 and 2.12.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,6 @@ jobs:
           path: ~/.sbt
           key: sbt-${{ hashFiles('**/build.sbt') }}
       - name: Compile
-        run: sbt clean compile test:compile
+        run: sbt clean +compile +test:compile
       - name: Test
-        run: sbt test
+        run: sbt +test

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ lazy val site = project
 // General Settings
 lazy val commonSettings = Seq(
   scalaVersion := scalaV,
-  crossScalaVersions := Seq(scalaV, "2.12.10"),
+  crossScalaVersions := Seq(scalaV, "2.12.11"),
   addCompilerPlugin("org.typelevel" %% "kind-projector"     % kindProjectorV cross CrossVersion.full),
   addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV),
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -86,13 +86,14 @@ lazy val site = project
 // General Settings
 lazy val commonSettings = Seq(
   scalaVersion := scalaV,
-  crossScalaVersions := Seq(scalaV),
+  crossScalaVersions := Seq(scalaV, "2.12.10"),
   addCompilerPlugin("org.typelevel" %% "kind-projector"     % kindProjectorV cross CrossVersion.full),
   addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV),
   libraryDependencies ++= Seq(
     "org.typelevel"     %% "cats-core"        % catsV,
     "org.typelevel"     %% "cats-effect"      % catsEffectV,
     "co.fs2"            %% "fs2-core"         % fs2V,
+    "co.fs2"            %% "fs2-io"           % fs2V,
     "io.chrisdavenport" %% "log4cats-core"    % log4catsV,
     "io.chrisdavenport" %% "log4cats-slf4j"   % log4catsV,
     "io.chrisdavenport" %% "log4cats-testing" % log4catsV % Test,


### PR DESCRIPTION
## What it does
- Support for 2.12.10
- Replace `LazyList` to use function provided by`fs2-io`

## Design consideration

At the moment I am creating the following, just to able to execute the effect inside the side effect method.

```scala
 import scala.concurrent.ExecutionContext.global
 implicit val contextShift = IO.contextShift(global)
```

However, I am not sure this is the right approach. Alternatives:

- Make this function external to this context and provide a side effect `trait` or `function`
- Provide as arguments `ContextShift` and `Bloker` at `IO` level
- Try to _lift_ the existing `ContextShift` and `Bloker` to the `IO` level
- Make the whole implementation at the `IO` level.

## Related issues
https://github.com/cats4scala/cats-process/issues/6