### PR TITLE
Refactor

### DIFF
--- a/core/src/main/scala/c4s/process/LoggerProcess.scala
+++ b/core/src/main/scala/c4s/process/LoggerProcess.scala
@@ -22,12 +22,12 @@ private[process] final class LoggerProcess[F[_]: Sync](process: Process[F], logg
       _ <- if (output.nonEmpty)
         logger.info(output)
       else
-        Sync[F].pure(())
+        Sync[F].unit
       error <- result.error.asString
       _ <- if (error.nonEmpty)
         logger.error(error)
       else
-        Sync[F].pure(())
+        Sync[F].unit
     } yield result.copy(
       output = Stream(output).through(text.utf8Encode),
       error = Stream(error).through(text.utf8Encode)

--- a/core/src/main/scala/c4s/process/LoggerProcess.scala
+++ b/core/src/main/scala/c4s/process/LoggerProcess.scala
@@ -1,0 +1,35 @@
+package c4s.process
+
+import cats.implicits._
+import cats.effect._
+import io.chrisdavenport.log4cats.Logger
+import c4s.process.syntax._
+import java.nio.file.Path
+import fs2.{text, Stream}
+
+private[process] final class LoggerProcess[F[_]: Sync](process: Process[F], logger: Logger[F]) extends Process[F] {
+
+  def run(command: String, path: Option[Path]): F[ProcessResult[F]] =
+    for {
+      result <- process.run(command, path)
+      newResult <- logProcessResult(path, command, result)
+    } yield newResult
+
+  private def logProcessResult(path: Option[Path], command: String, result: ProcessResult[F]): F[ProcessResult[F]] =
+    for {
+      _ <- logger.info(s"[${result.exitCode}] ${path.fold("")(x => s"$x/")}$command")
+      output <- result.output.asString
+      _ <- if (output.nonEmpty)
+        logger.info(output)
+      else
+        Sync[F].pure(())
+      error <- result.error.asString
+      _ <- if (error.nonEmpty)
+        logger.error(error)
+      else
+        Sync[F].pure(())
+    } yield result.copy(
+      output = Stream(output).through(text.utf8Encode),
+      error = Stream(error).through(text.utf8Encode)
+    )
+}

--- a/core/src/main/scala/c4s/process/LoggerProcess.scala
+++ b/core/src/main/scala/c4s/process/LoggerProcess.scala
@@ -9,7 +9,7 @@ import fs2.{text, Stream}
 
 private[process] final class LoggerProcess[F[_]: Sync](process: Process[F], logger: Logger[F]) extends Process[F] {
 
-  def run(command: String, path: Option[Path]): F[ProcessResult[F]] =
+  final def run(command: String, path: Option[Path]): F[ProcessResult[F]] =
     for {
       result <- process.run(command, path)
       newResult <- logProcessResult(path, command, result)

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -2,100 +2,69 @@ package c4s.process
 
 import cats.effect._
 import cats.implicits._
-import fs2.{text, Stream}
 import io.chrisdavenport.log4cats.Logger
 
 import java.io.InputStream
 import java.nio.file.Path
+import fs2.Stream
 
 trait Process[F[_]] {
-  def run(command: String): F[ProcessResult[F]]
-  def run(command: String, path: Path): F[ProcessResult[F]]
+  def run(command: String, path: Option[Path]): F[ProcessResult[F]]
 }
 
 object Process {
   import scala.sys.process.{Process => ScalaProcess, _}
   def apply[F[_]](implicit process: Process[F]): Process[F] = process
 
+  def run[F[_]: Process](command: String): F[ProcessResult[F]] = Process[F].run(command, None)
+  def runInPath[F[_]: Process](command: String, path: Path): F[ProcessResult[F]] = Process[F].run(command, path.some)
+
   implicit class ProcessOps[F[_]: Sync](process: Process[F]) {
-
-    def withLogger(logger: Logger[F]): Process[F] = new Process[F] {
-
-      def run(command: String): F[ProcessResult[F]] =
-        for {
-          result <- process.run(command)
-          newResult <- logProcessResult(None, command, result)
-        } yield newResult
-
-      def run(command: String, path: Path): F[ProcessResult[F]] =
-        for {
-          result <- process.run(command, path)
-          newResult <- logProcessResult(path.some, command, result)
-        } yield newResult
-
-      def logProcessResult(path: Option[Path], command: String, result: ProcessResult[F]): F[ProcessResult[F]] =
-        for {
-          _ <- logger.info(s"[${result.exitCode}] ${path.fold("")(x => s"$x/")}$command")
-          output <- ProcessResult.mkString(result.output)
-          _ <- if (output.nonEmpty)
-            logger.info(output)
-          else
-            Sync[F].pure(())
-          error <- ProcessResult.mkString(result.error)
-          _ <- if (error.nonEmpty)
-            logger.error(error)
-          else
-            Sync[F].pure(())
-        } yield result.copy(
-          output = Stream(output).through(text.utf8Encode),
-          error = Stream(error).through(text.utf8Encode)
-        )
-    }
+    def withLogger(logger: Logger[F]): Process[F] = new LoggerProcess(process, logger)
   }
 
   def impl[F[_]: Sync: Bracket[?[_], Throwable]: ContextShift](
       blocker: Blocker
-  ): Process[F] =
-    new Process[F] {
-      import java.util.concurrent.atomic.AtomicReference
-      val atomicReference = Sync[F].delay(new AtomicReference[Stream[F, Byte]])
+  ): Process[F] = new ProcessImpl[F](blocker)
 
-      def run(command: String): F[ProcessResult[F]] = run(command, None)
-      def run(command: String, path: Path): F[ProcessResult[F]] = run(command, path.some)
+  private[this] final class ProcessImpl[F[_]: Sync: Bracket[?[_], Throwable]: ContextShift](blocker: Blocker)
+      extends Process[F] {
+    import java.util.concurrent.atomic.AtomicReference
+    val atomicReference = Sync[F].delay(new AtomicReference[Stream[F, Byte]])
 
-      def run(command: String, path: Option[Path]): F[ProcessResult[F]] =
-        for {
-          outputRef <- atomicReference
-          errorRef <- atomicReference
-          exitValue <- Bracket[F, Throwable].bracket(Sync[F].delay {
-            val p = new ProcessIO(
-              _ => (),
-              redirectInputStream(outputRef, _),
-              redirectInputStream(errorRef, _)
-            )
-            path.fold(
-              ScalaProcess(command).run(p)
-            )(path => ScalaProcess(command, path.toFile()).run(p))
-          })(p => blocker.blockOn(Sync[F].delay(p.exitValue())))(p => Sync[F].delay(p.destroy()))
-          output <- Sync[F].delay(outputRef.get())
-          error <- Sync[F].delay(errorRef.get())
-        } yield ProcessResult(ExitCode(exitValue), output, error)
+    def run(command: String, path: Option[Path]): F[ProcessResult[F]] =
+      for {
+        outputRef <- atomicReference
+        errorRef <- atomicReference
+        exitValue <- Bracket[F, Throwable].bracket(Sync[F].delay {
+          val p = new ProcessIO(
+            _ => (),
+            redirectInputStream(outputRef, _),
+            redirectInputStream(errorRef, _)
+          )
+          path.fold(
+            ScalaProcess(command).run(p)
+          )(path => ScalaProcess(command, path.toFile()).run(p))
+        })(p => blocker.blockOn(Sync[F].delay(p.exitValue())))(p => Sync[F].delay(p.destroy()))
+        output <- Sync[F].delay(outputRef.get())
+        error <- Sync[F].delay(errorRef.get())
+      } yield ProcessResult(ExitCode(exitValue), output, error)
 
-      private[this] def redirectInputStream(
-          ref: AtomicReference[Stream[F, Byte]],
-          is: InputStream
-      ): Unit =
-        try {
-          import scala.collection.immutable.LazyList
-          val output = LazyList
-            .continually(is.read)
-            .takeWhile(_ != -1)
-            .map(_.toByte)
-            .iterator
-            .toArray
-          ref.set(Stream.fromIterator(output.iterator))
-        } finally {
-          is.close()
-        }
-    }
+    private[this] def redirectInputStream(
+        ref: AtomicReference[Stream[F, Byte]],
+        is: InputStream
+    ): Unit =
+      try {
+        import scala.collection.immutable.LazyList
+        val output = LazyList
+          .continually(is.read)
+          .takeWhile(_ != -1)
+          .map(_.toByte)
+          .iterator
+          .toArray
+        ref.set(Stream.fromIterator(output.iterator))
+      } finally {
+        is.close()
+      }
+  }
 }

--- a/core/src/main/scala/c4s/process/ProcessResult.scala
+++ b/core/src/main/scala/c4s/process/ProcessResult.scala
@@ -1,17 +1,10 @@
 package c4s.process
 
 import cats.effect._
-import cats.implicits._
-import fs2.{text, Stream}
+import fs2.Stream
 
 final case class ProcessResult[F[_]](
     exitCode: ExitCode,
     output: Stream[F, Byte],
     error: Stream[F, Byte]
 )
-
-object ProcessResult {
-
-  def mkString[F[_]: Sync](stream: Stream[F, Byte]): F[String] =
-    stream.through(text.utf8Decode).compile.toVector.map(_.mkString)
-}

--- a/core/src/main/scala/c4s/process/ProcessResult.scala
+++ b/core/src/main/scala/c4s/process/ProcessResult.scala
@@ -8,3 +8,6 @@ final case class ProcessResult[F[_]](
     output: Stream[F, Byte],
     error: Stream[F, Byte]
 )
+
+final case class ProcessFailure[F[_]](result: ProcessResult[F])
+    extends RuntimeException(s"Failed to execute command with exit code ${result.exitCode.code}")

--- a/core/src/main/scala/c4s/process/syntax/package.scala
+++ b/core/src/main/scala/c4s/process/syntax/package.scala
@@ -23,5 +23,10 @@ package object syntax {
   implicit class ProcessResultOps[F[_]: Sync](result: F[ProcessResult[F]]) {
     def lines: F[List[String]] = result.flatMap(_.output.asLines)
     def string: F[String] = result.flatMap(_.output.asString)
+
+    def strict: F[(ExitCode, Stream[F, Byte])] = result.flatMap {
+      case r if r.exitCode == ExitCode.Success => Sync[F].pure(r.exitCode -> r.output)
+      case r => Sync[F].raiseError(new ProcessFailure(r))
+    }
   }
 }

--- a/core/src/main/scala/c4s/process/syntax/package.scala
+++ b/core/src/main/scala/c4s/process/syntax/package.scala
@@ -1,0 +1,27 @@
+package c4s.process
+
+import cats.implicits._
+import cats.effect._
+import fs2.{text, Stream}
+
+package object syntax {
+
+  implicit class StreamBytesOps[F[_]: Sync](stream: Stream[F, Byte]) {
+
+    def asString: F[String] =
+      stream
+        .through(text.utf8Decode)
+        .compile
+        .toVector
+        .map(_.mkString)
+
+    def asLines: F[List[String]] =
+      asString
+        .map(_.split('\n').toList)
+  }
+
+  implicit class ProcessResultOps[F[_]: Sync](result: F[ProcessResult[F]]) {
+    def lines: F[List[String]] = result.flatMap(_.output.asLines)
+    def string: F[String] = result.flatMap(_.output.asString)
+  }
+}

--- a/core/src/main/scala/c4s/process/syntax/package.scala
+++ b/core/src/main/scala/c4s/process/syntax/package.scala
@@ -6,25 +6,30 @@ import fs2.{text, Stream}
 
 package object syntax {
 
+  implicit class ProcessOps[F[_]: Sync](process: Process[F]) {
+    import io.chrisdavenport.log4cats.Logger
+    final def withLogger(logger: Logger[F]): Process[F] = new LoggerProcess(process, logger)
+  }
+
   implicit class StreamBytesOps[F[_]: Sync](stream: Stream[F, Byte]) {
 
-    def asString: F[String] =
+    final def asString: F[String] =
       stream
         .through(text.utf8Decode)
         .compile
         .toVector
         .map(_.mkString)
 
-    def asLines: F[List[String]] =
+    final def asLines: F[List[String]] =
       asString
         .map(_.split('\n').toList)
   }
 
   implicit class ProcessResultOps[F[_]: Sync](result: F[ProcessResult[F]]) {
-    def lines: F[List[String]] = result.flatMap(_.output.asLines)
-    def string: F[String] = result.flatMap(_.output.asString)
+    final def lines: F[List[String]] = result.flatMap(_.output.asLines)
+    final def string: F[String] = result.flatMap(_.output.asString)
 
-    def strict: F[(ExitCode, Stream[F, Byte])] = result.flatMap {
+    final def strict: F[(ExitCode, Stream[F, Byte])] = result.flatMap {
       case r if r.exitCode == ExitCode.Success => Sync[F].pure(r.exitCode -> r.output)
       case r => Sync[F].raiseError(new ProcessFailure(r))
     }

--- a/core/src/test/scala/c4s/process/LoggerProcessSpec.scala
+++ b/core/src/test/scala/c4s/process/LoggerProcessSpec.scala
@@ -1,0 +1,42 @@
+package c4s.process
+
+import io.chrisdavenport.log4cats.testing.TestingLogger
+import io.chrisdavenport.log4cats.testing.TestingLogger._
+import cats.effect._
+import org.specs2.mutable.Specification
+import scala.concurrent.ExecutionContext
+
+class LoggerProcessSpec extends Specification {
+  implicit val executionContext = ExecutionContext.global
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(executionContext)
+
+  "Process should be able to" >> {
+    import c4s.process.syntax._
+
+    "to log what we are doing and still getting the command when it is succeeded" >> {
+      withProcess { (shell, logger) =>
+        for {
+          output <- Process.run("ls -la")(shell).string
+          log <- logger.logged
+        } yield log.collect { case INFO(message, _) => message } must contain(output)
+      }.unsafeRunSync()
+    }
+
+    "to log what we are doing and still getting the command when it fails" >> {
+      withProcess { (shell, logger) =>
+        for {
+          result <- Process.run("ls foo")(shell)
+          error <- result.error.asString
+          log <- logger.logged
+        } yield log.collect { case ERROR(message, _) => message } must contain(error)
+      }.unsafeRunSync()
+    }
+  }
+
+  def withProcess[R](f: (Process[IO], TestingLogger[IO]) => IO[R]): IO[R] = {
+    val logger = TestingLogger.impl[IO]()
+    Blocker[IO]
+      .use(x => f(Process.impl[IO](x).withLogger(logger), logger))
+  }
+
+}

--- a/core/src/test/scala/c4s/process/LoggerProcessSpec.scala
+++ b/core/src/test/scala/c4s/process/LoggerProcessSpec.scala
@@ -7,11 +7,11 @@ import org.specs2.mutable.Specification
 import scala.concurrent.ExecutionContext
 
 class LoggerProcessSpec extends Specification {
+  import c4s.process.syntax._
   implicit val executionContext = ExecutionContext.global
   implicit val contextShift: ContextShift[IO] = IO.contextShift(executionContext)
 
   "Process should be able to" >> {
-    import c4s.process.syntax._
 
     "to log what we are doing and still getting the command when it is succeeded" >> {
       withProcess { (shell, logger) =>

--- a/core/src/test/scala/c4s/process/ProcessSpec.scala
+++ b/core/src/test/scala/c4s/process/ProcessSpec.scala
@@ -19,6 +19,16 @@ class ProcessSpec extends Specification {
         .unsafeRunSync()
     }
 
+    "strict run commands" >> {
+      withProcess(implicit shell => Process.run("ls -la").strict.map(_._1 must ===(ExitCode.Success)))
+        .unsafeRunSync()
+    }
+
+    "strict run commands when it is failing" >> {
+      withProcess(implicit shell => Process.run("ls foo").strict)
+        .unsafeRunSync() must throwA[ProcessFailure[IO]]
+    }
+
     "get the output as string and execute commands in different folder" >> {
       withProcess { implicit shell =>
         createTmpDirectory[IO].use { path =>


### PR DESCRIPTION
## What it does

- **Simplify the api**. We only have one method in trait and there are two new methods in the companion object that simplifies it uses: `run` and `runInPath`
- **Create syntactic sugar**: Just to get a simple way to access to the content and provide a way to execute `strict` the command. `strict` mode allows us to execute command and in case it is failing lift the failure in the context of the `F`. 
- **Small improvements**: Create `ProcessImpl` at an internal private class and move out into a different file `LoggerProcess` with its own private class.