### PR TITLE
Support crossbuild for Scala 2.13.1 and 2.12.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,6 @@ jobs:
           path: ~/.sbt
           key: sbt-${{ hashFiles('**/build.sbt') }}
       - name: Compile
-        run: sbt clean compile test:compile
+        run: sbt clean +compile +test:compile
       - name: Test
-        run: sbt test
+        run: sbt +test

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ lazy val site = project
 // General Settings
 lazy val commonSettings = Seq(
   scalaVersion := scalaV,
-  crossScalaVersions := Seq(scalaV),
+  crossScalaVersions := Seq(scalaV, "2.12.11"),
   addCompilerPlugin("org.typelevel" %% "kind-projector"     % kindProjectorV cross CrossVersion.full),
   addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV),
   libraryDependencies ++= Seq(

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -54,7 +54,7 @@ object Process {
       try {
         val queue = scala.collection.mutable.Queue.empty[Byte]
         var n = is.read()
-        while(n != -1) {
+        while (n != -1) {
           queue.enqueue(n.toByte)
           n = is.read()
         }

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -52,14 +52,13 @@ object Process {
         is: InputStream
     ): Unit =
       try {
-        import scala.collection.immutable.LazyList
-        val output = LazyList
-          .continually(is.read)
-          .takeWhile(_ != -1)
-          .map(_.toByte)
-          .iterator
-          .toArray
-        ref.set(Stream.fromIterator(output.iterator))
+        val queue = scala.collection.mutable.Queue.empty[Byte]
+        var n = is.read()
+        while(n != -1) {
+          queue.enqueue(n.toByte)
+          n = is.read()
+        }
+        ref.set(Stream.fromIterator(queue.iterator))
       } finally {
         is.close()
       }


### PR DESCRIPTION
## What it does

Support crossbuild for Scala 2.13.1 and 2.12.10

## Design consideration

Given we cannot avoid side effect at the moment when reading output/error stream, I propose to adopt a traditional  mutable (side effect) approach to support both version. In this case, the mutability is located in the scope of the method.

## Related issues
- [Support crossbuild for Scala 2.13.1 and 2.12.10](https://github.com/cats4scala/cats-process/issues/6)