### PR TITLE
Fix GH Release trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,9 +40,9 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
 
   gh-release:
-    name: Create Release ${{ github.ref }}
+    name: Create GH Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'tags'
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs: release
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- :rocket: GitHub Release job in release workflow
 
 ## [0.0.1] - 2020-04-07
 ### Added


### PR DESCRIPTION
# What it does

Fix GH Release creation when a new stable release is made, checking properly it is a new tag event.

Fix #45 

## Checklist

- [x] Update `CHANGELOG.md`
- [x] Refenrence issue
- [x] Labels
