### PR TITLE
Handle Byte stream as an input of a command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Validate CHANGELOG in CI workflow
 - Close CHANGELOG version automatically when a new release is made
-- Refactor code to adds an optional stream parameter in the run method of Process 
+- Handle input for `Process`es
 
 ### Changed
 - Update `specs2` to 4.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - Validate CHANGELOG in CI workflow
+- Refactor code to adds an optional stream parameter in the run method of Process 
 
 ### Fixed
 - :rocket: GitHub Release job in release workflow

--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ lazy val commonSettings = Seq(
     "org.typelevel"     %% "cats-core"        % catsV,
     "org.typelevel"     %% "cats-effect"      % catsEffectV,
     "co.fs2"            %% "fs2-core"         % fs2V,
+    "co.fs2"            %% "fs2-io"           % fs2V,
     "io.chrisdavenport" %% "log4cats-core"    % log4catsV,
     "io.chrisdavenport" %% "log4cats-slf4j"   % log4catsV,
     "io.chrisdavenport" %% "log4cats-testing" % log4catsV % Test,

--- a/core/src/main/scala/c4s/process/Extract.scala
+++ b/core/src/main/scala/c4s/process/Extract.scala
@@ -14,4 +14,3 @@ object Extract {
     override def extract[A](fa: IO[A]): A = fa.unsafeRunSync()
   }
 }
-

--- a/core/src/main/scala/c4s/process/Extract.scala
+++ b/core/src/main/scala/c4s/process/Extract.scala
@@ -1,0 +1,17 @@
+package c4s.process
+
+import cats.effect.IO
+
+trait Extract[F[_]] {
+  def extract[A](fa: F[A]): A
+}
+
+object Extract {
+
+  final def apply[F[_]](implicit extract: Extract[F]): Extract[F] = extract
+
+  implicit val extractIO: Extract[IO] = new Extract[IO] {
+    override def extract[A](fa: IO[A]): A = fa.unsafeRunSync()
+  }
+}
+

--- a/core/src/main/scala/c4s/process/LoggerProcess.scala
+++ b/core/src/main/scala/c4s/process/LoggerProcess.scala
@@ -11,7 +11,7 @@ private[process] final class LoggerProcess[F[_]: Sync](process: Process[F], logg
 
   override final def run(command: String, input: Option[Stream[F, Byte]], path: Option[Path]): F[ProcessResult[F]] =
     for {
-      result <- process.run(command, stream, path)
+      result <- process.run(command, input, path)
       newResult <- logProcessResult(path, command, result)
     } yield newResult
 

--- a/core/src/main/scala/c4s/process/LoggerProcess.scala
+++ b/core/src/main/scala/c4s/process/LoggerProcess.scala
@@ -9,13 +9,11 @@ import fs2.{text, Stream}
 
 private[process] final class LoggerProcess[F[_]: Sync](process: Process[F], logger: Logger[F]) extends Process[F] {
 
-  final def run(command: String, path: Option[Path]): F[ProcessResult[F]] =
+  override final def run(command: String, stream:Option[Stream[F, Byte]], path: Option[Path]): F[ProcessResult[F]] =
     for {
-      result <- process.run(command, path)
+      result <- process.run(command, stream, path)
       newResult <- logProcessResult(path, command, result)
     } yield newResult
-
-  final def run(command: String, stream: Stream[F, Byte], path: Option[Path]): F[ProcessResult[F]] = ???
 
   private def logProcessResult(path: Option[Path], command: String, result: ProcessResult[F]): F[ProcessResult[F]] =
     for {

--- a/core/src/main/scala/c4s/process/LoggerProcess.scala
+++ b/core/src/main/scala/c4s/process/LoggerProcess.scala
@@ -15,6 +15,8 @@ private[process] final class LoggerProcess[F[_]: Sync](process: Process[F], logg
       newResult <- logProcessResult(path, command, result)
     } yield newResult
 
+  final def run(command: String, stream: Stream[F, Byte], path: Option[Path]): F[ProcessResult[F]] = ???
+
   private def logProcessResult(path: Option[Path], command: String, result: ProcessResult[F]): F[ProcessResult[F]] =
     for {
       _ <- logger.info(s"[${result.exitCode}] ${path.fold("")(x => s"$x/")}$command")

--- a/core/src/main/scala/c4s/process/LoggerProcess.scala
+++ b/core/src/main/scala/c4s/process/LoggerProcess.scala
@@ -9,7 +9,7 @@ import fs2.{text, Stream}
 
 private[process] final class LoggerProcess[F[_]: Sync](process: Process[F], logger: Logger[F]) extends Process[F] {
 
-  override final def run(command: String, stream:Option[Stream[F, Byte]], path: Option[Path]): F[ProcessResult[F]] =
+  override final def run(command: String, input: Option[Stream[F, Byte]], path: Option[Path]): F[ProcessResult[F]] =
     for {
       result <- process.run(command, stream, path)
       newResult <- logProcessResult(path, command, result)

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -2,10 +2,12 @@ package c4s.process
 
 import cats.effect._
 import cats.implicits._
-
-import java.io.InputStream
+import java.io.{InputStream, OutputStream}
 import java.nio.file.Path
+
+import cats.Bimonad
 import fs2.Stream
+import fs2.io.writeOutputStream
 
 trait Process[F[_]] {
   def run(command: String, path: Option[Path]): F[ProcessResult[F]]
@@ -21,22 +23,24 @@ object Process {
   final def runInPath[F[_]: Process](command: String, path: Path): F[ProcessResult[F]] =
     Process[F].run(command, path.some)
 
-  final def impl[F[_]: Sync: Bracket[?[_], Throwable]: ContextShift](
+  final def impl[F[_]: Concurrent: Bracket[?[_], Throwable]: ContextShift: Bimonad](
       blocker: Blocker
   ): Process[F] = new ProcessImpl[F](blocker)
 
-  private[this] final class ProcessImpl[F[_]: Sync: Bracket[?[_], Throwable]: ContextShift](blocker: Blocker)
+  private[this] final class ProcessImpl[F[_]: Concurrent: Bracket[?[_], Throwable]: ContextShift: Bimonad](blocker: Blocker)
       extends Process[F] {
     import java.util.concurrent.atomic.AtomicReference
     val atomicReference = Sync[F].delay(new AtomicReference[Stream[F, Byte]])
 
-    final def run(command: String, path: Option[Path]): F[ProcessResult[F]] =
+    private final def runStream(command: String, stream: Option[Stream[F, Byte]], path: Option[Path]): F[ProcessResult[F]] =
       for {
         outputRef <- atomicReference
         errorRef <- atomicReference
+        fout = toOutputStream(stream)
         exitValue <- Bracket[F, Throwable].bracket(Sync[F].delay {
           val p = new ProcessIO(
-            _ => (),
+            fout andThen(Bimonad[F].extract),
+            //_ => (),
             redirectInputStream(outputRef, _),
             redirectInputStream(errorRef, _)
           )
@@ -48,7 +52,16 @@ object Process {
         error <- Sync[F].delay(errorRef.get())
       } yield ProcessResult(ExitCode(exitValue), output, error)
 
-    final def run(command: String, stream: Stream[F, Byte], path: Option[Path]): F[ProcessResult[F]] = ???
+    def toOutputStream(opt: Option[Stream[F, Byte]]): OutputStream => F[Unit] = out =>
+      opt.fold(Sync[F].unit){ stream =>
+        Resource.fromAutoCloseableBlocking(blocker)(Sync[F].delay {out})
+          .use { outStream =>
+            stream
+              .through(writeOutputStream[F](Concurrent[F].delay(outStream), blocker))
+              .compile
+              .drain
+          }
+      }
 
     private[this] def redirectInputStream(
         ref: AtomicReference[Stream[F, Byte]],
@@ -65,5 +78,11 @@ object Process {
       } finally {
         is.close()
       }
+
+    override def run(command: String, path: Option[Path]): F[ProcessResult[F]] =
+      runStream(command, None, path)
+
+    override def run(command: String, stream: Stream[F, Byte], path: Option[Path]): F[ProcessResult[F]] =
+      runStream(command, Some(stream), path)
   }
 }

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -17,7 +17,7 @@ object Process {
 
   final def run[F[_]: Process](command: String): F[ProcessResult[F]] = Process[F].run(command, None, None)
 
-  final def run[F[_]: Process](command: String, stream: Stream[F, Byte]): F[ProcessResult[F]] = Process[F].run(command, Some(stream), None)
+  final def run[F[_]: Process](command: String, input: Stream[F, Byte]): F[ProcessResult[F]] = Process[F].run(command, Some(stream), None)
 
   final def runInPath[F[_]: Process](command: String, path: Path): F[ProcessResult[F]] =
     Process[F].run(command, None, path.some)

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -8,7 +8,7 @@ import fs2.Stream
 import fs2.io.writeOutputStream
 
 trait Process[F[_]] {
-  def run(command: String, stream: Option[Stream[F, Byte]], path: Option[Path]): F[ProcessResult[F]]
+  def run(command: String, input: Option[Stream[F, Byte]], path: Option[Path]): F[ProcessResult[F]]
 }
 
 object Process {

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -35,7 +35,7 @@ object Process {
       for {
         outputRef <- atomicReference
         errorRef <- atomicReference
-        fout = toOutputStream(stream)
+        fout = toOutputStream(input)
         exitValue <- Bracket[F, Throwable].bracket(Sync[F].delay {
           val p = new ProcessIO(
             fout andThen(Extract[F].extract),

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -76,6 +76,5 @@ object Process {
       } finally {
         is.close()
       }
-
   }
 }

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -31,7 +31,7 @@ object Process {
     import java.util.concurrent.atomic.AtomicReference
     val atomicReference = Sync[F].delay(new AtomicReference[Stream[F, Byte]])
 
-    override def run(command: String, stream: Option[Stream[F, Byte]], path: Option[Path]): F[ProcessResult[F]] =
+    override def run(command: String, input: Option[Stream[F, Byte]], path: Option[Path]): F[ProcessResult[F]] =
       for {
         outputRef <- atomicReference
         errorRef <- atomicReference

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -17,6 +17,8 @@ object Process {
 
   final def run[F[_]: Process](command: String): F[ProcessResult[F]] = Process[F].run(command, None, None)
 
+  final def run[F[_]: Process](command: String, stream: Stream[F, Byte]): F[ProcessResult[F]] = Process[F].run(command, Some(stream), None)
+
   final def runInPath[F[_]: Process](command: String, path: Path): F[ProcessResult[F]] =
     Process[F].run(command, None, path.some)
 
@@ -74,5 +76,6 @@ object Process {
       } finally {
         is.close()
       }
+
   }
 }

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -55,7 +55,7 @@ object Process {
         Resource.fromAutoCloseableBlocking(blocker)(Sync[F].delay {out})
           .use { outStream =>
             stream
-              .through(writeOutputStream[F](Concurrent[F].delay(outStream), blocker))
+              .through(writeOutputStream[F](Concurrent[F].delay(outStream), blocker, false))
               .compile
               .drain
           }

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -17,7 +17,7 @@ object Process {
 
   final def run[F[_]: Process](command: String): F[ProcessResult[F]] = Process[F].run(command, None, None)
 
-  final def run[F[_]: Process](command: String, input: Stream[F, Byte]): F[ProcessResult[F]] = Process[F].run(command, Some(stream), None)
+  final def run[F[_]: Process](command: String, input: Stream[F, Byte]): F[ProcessResult[F]] = Process[F].run(command, Some(input), None)
 
   final def runInPath[F[_]: Process](command: String, path: Path): F[ProcessResult[F]] =
     Process[F].run(command, None, path.some)
@@ -50,7 +50,7 @@ object Process {
         error <- Sync[F].delay(errorRef.get())
       } yield ProcessResult(ExitCode(exitValue), output, error)
 
-    def toOutputStream(opt: Option[Stream[F, Byte]]): OutputStream => F[Unit] = out =>
+    private[this] def toOutputStream(opt: Option[Stream[F, Byte]]): OutputStream => F[Unit] = out =>
       opt.fold(Sync[F].unit){ stream =>
         Resource.fromAutoCloseableBlocking(blocker)(Sync[F].delay {out})
           .use { outStream =>

--- a/core/src/main/scala/c4s/process/Process.scala
+++ b/core/src/main/scala/c4s/process/Process.scala
@@ -9,6 +9,7 @@ import fs2.Stream
 
 trait Process[F[_]] {
   def run(command: String, path: Option[Path]): F[ProcessResult[F]]
+  def run(command: String, stream: Stream[F, Byte], path: Option[Path]): F[ProcessResult[F]]
 }
 
 object Process {
@@ -46,6 +47,8 @@ object Process {
         output <- Sync[F].delay(outputRef.get())
         error <- Sync[F].delay(errorRef.get())
       } yield ProcessResult(ExitCode(exitValue), output, error)
+
+    final def run(command: String, stream: Stream[F, Byte], path: Option[Path]): F[ProcessResult[F]] = ???
 
     private[this] def redirectInputStream(
         ref: AtomicReference[Stream[F, Byte]],

--- a/core/src/test/scala/c4s/process/ProcessSpec.scala
+++ b/core/src/test/scala/c4s/process/ProcessSpec.scala
@@ -64,7 +64,7 @@ class ProcessSpec extends Specification {
           for {
             _ <- Process.runInPath("touch test-file", path)
             result <- Process.runInPath("ls", path)
-            resultStream <- Process.runInPath("wc", result.output, path)
+            resultStream <- Process.run("wc", result.output)
           } yield resultStream.exitCode == (ExitCode.Success)
         }
       }.unsafeRunSync()

--- a/core/src/test/scala/c4s/process/ProcessSpec.scala
+++ b/core/src/test/scala/c4s/process/ProcessSpec.scala
@@ -64,8 +64,9 @@ class ProcessSpec extends Specification {
           for {
             _ <- Process.runInPath("touch test-file", path)
             result <- Process.runInPath("ls", path)
-            resultStream <- Process.run("wc", result.output)
-          } yield resultStream.exitCode == (ExitCode.Success)
+            resultStream <- Process.run("wc", result.output).string
+            value = resultStream.replaceAll(" ", "").trim.toInt
+          } yield value should_==(1110)
         }
       }.unsafeRunSync()
     }

--- a/core/src/test/scala/c4s/process/ProcessSpec.scala
+++ b/core/src/test/scala/c4s/process/ProcessSpec.scala
@@ -66,7 +66,7 @@ class ProcessSpec extends Specification {
             result <- Process.runInPath("ls", path)
             resultStream <- Process.run("wc", result.output).string
             value = resultStream.replaceAll(" ", "").trim.toInt
-          } yield value should_==(1110)
+          } yield value should_== (1110)
         }
       }.unsafeRunSync()
     }

--- a/core/src/test/scala/c4s/process/ProcessSpec.scala
+++ b/core/src/test/scala/c4s/process/ProcessSpec.scala
@@ -58,6 +58,15 @@ class ProcessSpec extends Specification {
       }.unsafeRunSync()
     }
 
+    "run command reading a stream from another command" >> {
+      withProcess{ implicit shell =>
+        for {
+          result <- Process.run("ls -las")
+          resultStream <- Process.run("wc", result.output)
+        } yield resultStream.exitCode == (ExitCode.Success)
+      }.unsafeRunSync()
+    }
+
   }
 
   def withProcess[R](f: Process[IO] => IO[R]): IO[R] =

--- a/core/src/test/scala/c4s/process/ProcessSpec.scala
+++ b/core/src/test/scala/c4s/process/ProcessSpec.scala
@@ -59,11 +59,14 @@ class ProcessSpec extends Specification {
     }
 
     "run command reading a stream from another command" >> {
-      withProcess{ implicit shell =>
-        for {
-          result <- Process.run("ls -las")
-          resultStream <- Process.run("wc", result.output)
-        } yield resultStream.exitCode == (ExitCode.Success)
+      withProcess { implicit shell =>
+        createTmpDirectory[IO].use { path =>
+          for {
+            _ <- Process.runInPath("touch test-file", path)
+            result <- Process.runInPath("ls", path)
+            resultStream <- Process.runInPath("wc", result.output, path)
+          } yield resultStream.exitCode == (ExitCode.Success)
+        }
       }.unsafeRunSync()
     }
 


### PR DESCRIPTION
# What it does

Handle `Stream[F, Byte]` as an input of a command. This pr
- Adds an optional parameter with the stream.
- Refactor the code to use this parameter.
- Add a new test for testing the use of a stream in a process.

Close https://github.com/cats4scala/cats-process/issues/7

## Checklist

- [x] Update `CHANGELOG.md`
- [ ] Update documentation
- [x] Reference issue
- [x] Labels
