### PR TITLE
Automate changelog on release

### DIFF
--- a/.github/.kacl.yaml
+++ b/.github/.kacl.yaml
@@ -1,0 +1,5 @@
+kacl:
+  links:
+    compare_versions_template: '{host}/tree/v{previous_version}...v{version}'
+    unreleased_changes_template: '{host}/compare/v{latest_version}...HEAD'
+    initial_version_template: '{host}/compare/v{version}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,4 +91,4 @@ jobs:
       - name: Install python-kacl
         run: pip install python-kacl
       - name: Verify CHANGELOG.md
-        run: kacl-cli verify
+        run: kacl-cli --config .github/.kacl.yaml verify

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,6 +63,39 @@ jobs:
           draft: true
           prerelease: false
 
+  changelog:
+    name: changelog
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'ref/tags') }}
+    needs: release
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install python-kacl
+        run: pip install python-kacl
+      - id: vars
+        run: |
+          echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+          echo ::set-output name=version::${GITHUB_REF/refs\/tags\/v/}
+      - run: git switch master
+      - name: Release ${{ steps.vars.outputs.version }} in CHANGELOG.md
+        run: kacl-cli --config .github/.kacl.yaml release ${{ steps.vars.outputs.version }} --auto-link --modify
+      - name: Commit CHANGELOG.md
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit --all --message "Close ${{ steps.vars.outputs.version }} release in CHANGELOG.md"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: master
+
   publish-microsite:
     name: publish microsite
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,5 +26,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Setup site: https://cats4scala.github.io/cats-process
 - Crossbuild project for Scala 2.12.11 and 2.13.1
 
-[Unreleased]: https://github.com/cats4scala/cats-process/tree/v0.0.1...HEAD
+[Unreleased]: https://github.com/cats4scala/cats-process/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/cats4scala/cats-process/compare/4ee110a...v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - Validate CHANGELOG in CI workflow
+- Close CHANGELOG version automatically when a new release is made
+
+### Changed
+- Update `specs2` to 4.9.3
+- Update `sbt-scalafmt` to 2.3.4
+- Update `sbt` to 1.3.10
+- Update `cats-effect` to 2.1.3
 
 ### Fixed
 - :rocket: GitHub Release job in release workflow


### PR DESCRIPTION
# What it does

When a new release is made (new tag), using `kacl-cli`, `CHANGELOG.md` is updated closing the release and preparing for the next `Unreleased` section.

Right now, it only supports releases on branch `master`.

Close #47 

## Checklist

- [x] Update `CHANGELOG.md`
- [x] Reference issue
- [x] Labels
